### PR TITLE
add xlrd dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sodapy==2.1.*
 smartsheet-python-sdk==3.0.*
 pyproj
 pytz
+xlrd


### PR DESCRIPTION
Need to add this dependency to use pandas `pd.read_excel`

`ImportError: Missing optional dependency 'xlrd'. Install xlrd >= 1.0.0 for Excel support Use pip or conda to install xlrd.
`